### PR TITLE
doc: explain how to use `paperToaster` service

### DIFF
--- a/tests/dummy/app/templates/demo/toast.hbs
+++ b/tests/dummy/app/templates/demo/toast.hbs
@@ -104,7 +104,7 @@
     <div class="doc-content-example">
       {{#paper-card-content}}
 
-        <p>Open a toast via <code>paperToaster</code> service and <code>\{{paper-toaster}}</code> component.</p>
+        <p>Open a toast via <code>paperToaster</code> service (once <code>\{{paper-toaster}}</code> has been added to a template).</p>
 
         <h3>Options</h3>
 


### PR DESCRIPTION
I'm not sure this is the best way to explain this, but I felt that the previous documentation did not offer any clues as to *how* to use the `{{paper-toaster}}` component. Someone kindly helped me out via Discord chat saying that `{{paper-toaster}}` needs to be added to the application template.